### PR TITLE
Fix contract file path

### DIFF
--- a/cmd/ebrelayer/contract/contract.go
+++ b/cmd/ebrelayer/contract/contract.go
@@ -15,7 +15,7 @@ import (
 )
 
 // AbiPath : path to the file containing the smart contract's ABI
-const AbiPath = "cmd/ebrelayer/contract/PeggyABI.json"
+const AbiPath = "/src/github.com/cosmos/peggy/cmd/ebrelayer/contract/PeggyABI.json"
 
 // LoadABI : loads a smart contract as an abi.ABI from a .json file
 func LoadABI() abi.ABI {


### PR DESCRIPTION
Contract file path was not correctly updated during the latest rebase. This hotfix returns contract.go to the most up-to-date state and allows the Relayer to correctly load the contract ABI.